### PR TITLE
Förhindra XSS från dropdown-menyn i session

### DIFF
--- a/example/stylechooser/chooser.php
+++ b/example/stylechooser/chooser.php
@@ -21,7 +21,8 @@ $key = isset($_SESSION['stylesheet'])
 if (isset($stylesheets[$key])) {
     $stylesheet = $stylesheets[$key];
 } else {
-    die("The value of key='$key' does not match a valid stylesheet.");
+    $safekey = htmlentities($key);
+    die("The value of key='$safekey' does not match a valid stylesheet.");
 }
 
 


### PR DESCRIPTION
Precis som Tomten sa på GrillCon så är det sällan utvecklare kommer ihåg att skydda sina dropdown-menyer från XSS. Även om det inte är något som användaren skriver in så går den fortfarande att ändra innan den skickas iväg till servern. I detta fallet så skrivs $key ut utan någon säkerhetskontroll.